### PR TITLE
network delay

### DIFF
--- a/nsl/stac/__init__.py
+++ b/nsl/stac/__init__.py
@@ -169,8 +169,12 @@ class __BearerAuth:
             self._token = res_body["access_token"]
         except json.JSONDecodeError:
             warnings.warn("failed to decode authentication json token")
+            self._expiry = 0
+            self._token = {}
         except BaseException as be:
             warnings.warn("failed to connect to authorization service with error: {0}".format(be))
+            self._expiry = 0
+            self._token = {}
 
     @property
     def expiry(self):


### PR DESCRIPTION
Kubernetes pod with application using nsl.stac might start the application before it has network connectivity. We don't want that to raise an exception.

There's also a delay environment variable, so that you would never see these warnings. Maybe we should do something like https://stackoverflow.com/a/29854274 instead.