### PR TITLE
Use debug message instead of warning for lacking env variables.

### DIFF
--- a/nsl/stac/__init__.py
+++ b/nsl/stac/__init__.py
@@ -358,7 +358,7 @@ class __BearerAuth:
 
     def __init__(self, init=False):
         if (not NSL_ID or not NSL_SECRET) and not NSL_CREDENTIALS.exists():
-            warnings.warn(f"NSL_ID and NSL_SECRET environment variables not set, and {NSL_CREDENTIALS} does not exist")
+            logger.debug(f"NSL_ID and NSL_SECRET environment variables not set, and {NSL_CREDENTIALS} does not exist")
             return
 
         # if credentials exist, add them to our auth store


### PR DESCRIPTION
There are several paths to do the authentication with this library. Populating environment variables initially is only one of it. But it throws some warnings. I would like to suggest to use a debug message instead.